### PR TITLE
fix: set Java target version to 1.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ apply from: "${gradleHelpersLocation}/readme2html.gradle"
 
 apply plugin: 'java'
 sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 sourceSets {
     test {


### PR DESCRIPTION
By default, Gradle won't specify a target Java version so it will produce bytecode for whatever JDK runs the build, meaning if JDK 17 is used, Java classes for 17 will be produced. This output won't work with Fortify since it runs Java 8. Therefore, the target version must be set to 1.8 for the output to be usable.

See: https://docs.gradle.org/current/userguide/java_plugin.html